### PR TITLE
Replace use of array in working buffers.

### DIFF
--- a/ci/deploy_to_device.py
+++ b/ci/deploy_to_device.py
@@ -27,7 +27,9 @@ def deploy(arch=""):
         deploy_py_files(Path("src/tempe/fonts"), ":/lib/tempe/fonts", arch=arch)
         deploy_py_files(Path("src/tempe/colormaps"), ":/lib/tempe/colormaps", arch=arch)
         deploy_py_files(Path("src/tempe_displays"), ":/lib/tempe_displays", arch=arch)
-        deploy_py_files(Path("src/tempe_displays/st7789"), ":/lib/tempe_displays/st7789", arch=arch)
+        deploy_py_files(
+            Path("src/tempe_displays/st7789"), ":/lib/tempe_displays/st7789", arch=arch
+        )
     except subprocess.CalledProcessError as exc:
         print("Error:")
         print(exc.stderr)

--- a/ci/test.py
+++ b/ci/test.py
@@ -19,7 +19,7 @@ def test():
     os.environ["MICROPYPATH"] = "src:" + os.environ.get(
         "MICROPYPATH", ":examples:.frozen:~/.micropython/lib:/usr/lib/micropython"
     )
-    for path in sorted(test_dir.glob("*.py")):
+    for path in sorted(test_dir.glob("test_*.py")):
         print(path.name, "... ", end="", flush=True)
         result = run_test(path)
         if result:

--- a/docs/source/user_guide/tutorial.rst
+++ b/docs/source/user_guide/tutorial.rst
@@ -34,16 +34,17 @@ Particularly for non-standard devices or interfaces, you may need to
 write this code, but there are examples of how to do this for common
 displays.
 
-You also need to provide a writable array of unsigned 16-bit integers
-that Tempe can use to render raster images into before copying them to
-the display.  The larger this chunk of memory is the better, but it can
-be allocated once and re-used repeatedly for drawing operations.
+You also need to provide a writable chunk of memory (such as a
+:py:class:`bytearray`) that Tempe can use to render raster images into before
+copying them to the display.  The larger this chunk of memory is the better,
+but it can (and probably *should*) be allocated once at the start of the
+application and re-used repeatedly for drawing operations.
 
 Actual drawing is performed by calling |refresh| with the display and
 the buffer::
 
     # a buffer one quarter the size of the screen
-    working_buffer = array('H', bytearray(2*320*61))
+    working_buffer = bytearray(2*320*61)
 
     # set up the display object
     display = ST7789()

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -5,7 +5,6 @@
 """Example showing basic display of text."""
 
 
-
 from tempe.surface import Surface
 from tempe.text import Text
 from tempe.shapes import Rectangles

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -4,7 +4,7 @@
 
 """Example showing basic display of text."""
 
-from array import array
+
 
 from tempe.surface import Surface
 from tempe.text import Text
@@ -14,8 +14,8 @@ from tempe.font import TempeFont
 from tempe.fonts import roboto16bold
 
 
-# a buffer one quarter the size of the screen
-working_buffer = array("H", bytearray(2 * 320 * 61))
+# a buffer one half the size of the screen
+working_buffer = bytearray(2 * 320 * 121)
 
 surface = Surface()
 

--- a/examples/line_plot_example.py
+++ b/examples/line_plot_example.py
@@ -160,7 +160,7 @@ surface.text(
 async def init_display():
     from tempe_displays.st7789.pimoroni import PimoroniDisplay
 
-    display = PimoroniDisplay(size = (240, 320))
+    display = PimoroniDisplay(size=(240, 320))
     display.backlight_pin(1)
     await display.init()
     return display

--- a/examples/line_plot_example.py
+++ b/examples/line_plot_example.py
@@ -4,7 +4,7 @@
 
 """Example showing how to create a line plot from Tempe Shapes."""
 
-from array import array
+
 import gc
 
 from tempe import colors
@@ -17,7 +17,7 @@ from tempe.surface import Surface
 surface = Surface()
 
 # a buffer one half the size of the screen
-working_buffer = array("H", range(320 * 121))
+working_buffer = bytearray(2 * 320 * 121)
 
 
 # fill the background with off-white pixels
@@ -162,7 +162,7 @@ async def init_display():
 
     display = PimoroniDisplay(size = (240, 320))
     display.backlight_pin(1)
-    await display.init(270)
+    await display.init()
     return display
 
 

--- a/examples/line_plot_example.py
+++ b/examples/line_plot_example.py
@@ -4,7 +4,7 @@
 
 """Example showing how to create a line plot from Tempe Shapes."""
 
-
+from array import array
 import gc
 
 from tempe import colors

--- a/examples/lines_example.py
+++ b/examples/lines_example.py
@@ -88,10 +88,11 @@ polylines = WidePolyLines(
 )
 surface.add_shape("DRAWING", polylines)
 
+
 async def init_display():
     from tempe_displays.st7789.pimoroni import PimoroniDisplay
 
-    display = PimoroniDisplay(size = (240, 320))
+    display = PimoroniDisplay(size=(240, 320))
     display.backlight_pin(1)
     await display.init()
     return display

--- a/examples/lines_example.py
+++ b/examples/lines_example.py
@@ -5,7 +5,7 @@
 """Example showing support for thick lines."""
 
 import asyncio
-
+from array import array
 import framebuf
 import random
 import math

--- a/examples/lines_example.py
+++ b/examples/lines_example.py
@@ -5,7 +5,7 @@
 """Example showing support for thick lines."""
 
 import asyncio
-from array import array
+
 import framebuf
 import random
 import math
@@ -24,8 +24,8 @@ random.seed(0)
 
 surface = Surface()
 
-# a buffer one quarter the size of the screen
-working_buffer = array("H", bytearray(2 * 320 * 61))
+# a buffer one half the size of the screen
+working_buffer = bytearray(2 * 320 * 121)
 
 # fill the background with white pixels
 background = Rectangles([(0, 0, 320, 240)], [0xFFFF])
@@ -93,7 +93,7 @@ async def init_display():
 
     display = PimoroniDisplay(size = (240, 320))
     display.backlight_pin(1)
-    await display.init(270)
+    await display.init()
     return display
 
 

--- a/examples/polar_example.py
+++ b/examples/polar_example.py
@@ -5,10 +5,7 @@
 """Example showing support for polar geometries."""
 
 import asyncio
-
-import framebuf
 import random
-import math
 
 from tempe.colors import grey_e, grey_3
 from tempe.colormaps.viridis import viridis

--- a/examples/polar_example.py
+++ b/examples/polar_example.py
@@ -214,7 +214,7 @@ surface.add_shape("DRAWING", donut)
 async def init_display():
     from tempe_displays.st7789.pimoroni import PimoroniDisplay
 
-    display = PimoroniDisplay(size = (240, 320))
+    display = PimoroniDisplay(size=(240, 320))
     display.backlight_pin(1)
     await display.init()
     return display

--- a/examples/polar_example.py
+++ b/examples/polar_example.py
@@ -5,7 +5,7 @@
 """Example showing support for polar geometries."""
 
 import asyncio
-from array import array
+
 import framebuf
 import random
 import math
@@ -29,8 +29,8 @@ random.seed(0)
 
 surface = Surface()
 
-# a buffer one quarter the size of the screen
-working_buffer = array("H", bytearray(2 * 320 * 61))
+# a buffer one half the size of the screen
+working_buffer = bytearray(2 * 320 * 121)
 
 # fill the background with white pixels
 background = Rectangles([(0, 0, 320, 240)], [0xFFFF])
@@ -219,7 +219,7 @@ async def init_display():
 
     display = PimoroniDisplay(size = (240, 320))
     display.backlight_pin(1)
-    await display.init(270)
+    await display.init()
     return display
 
 

--- a/examples/polar_plot_example.py
+++ b/examples/polar_plot_example.py
@@ -201,7 +201,7 @@ surface.text(
 async def init_display():
     from tempe_displays.st7789.pimoroni import PimoroniDisplay
 
-    display = PimoroniDisplay(size = (240, 320))
+    display = PimoroniDisplay(size=(240, 320))
     display.backlight_pin(1)
     await display.init()
     return display

--- a/examples/polar_plot_example.py
+++ b/examples/polar_plot_example.py
@@ -4,7 +4,7 @@
 
 """Example showing how to build a polar plot from Tempe Shapes."""
 
-from array import array
+
 import gc
 from math import sqrt, log
 
@@ -19,8 +19,8 @@ from tempe.surface import Surface
 
 surface = Surface()
 
-# a buffer one third the size of the screen
-working_buffer = array("H", range(320 * 81))
+# a buffer one half the size of the screen
+working_buffer = bytearray(2 * 320 * 121)
 
 
 # fill the background with off-black pixels
@@ -203,7 +203,7 @@ async def init_display():
 
     display = PimoroniDisplay(size = (240, 320))
     display.backlight_pin(1)
-    await display.init(270)
+    await display.init()
     return display
 
 

--- a/examples/polar_plot_example.py
+++ b/examples/polar_plot_example.py
@@ -4,7 +4,7 @@
 
 """Example showing how to build a polar plot from Tempe Shapes."""
 
-
+from array import array
 import gc
 from math import sqrt, log
 

--- a/examples/scatter_plot_example.py
+++ b/examples/scatter_plot_example.py
@@ -4,7 +4,7 @@
 
 """Example showing how to create a scatter plot from Tempe Shapes."""
 
-from array import array
+
 import gc
 from math import sqrt, log
 
@@ -20,7 +20,7 @@ from tempe.surface import Surface
 surface = Surface()
 
 # a buffer one half the size of the screen
-working_buffer = array("H", bytearray(2 * 320 * 121))
+working_buffer = bytearray(2 * 320 * 121)
 
 
 # fill the background with off-white pixels
@@ -370,7 +370,7 @@ async def init_display():
 
     display = PimoroniDisplay(size = (240, 320))
     display.backlight_pin(1)
-    await display.init(270)
+    await display.init()
     return display
 
 

--- a/examples/scatter_plot_example.py
+++ b/examples/scatter_plot_example.py
@@ -4,7 +4,7 @@
 
 """Example showing how to create a scatter plot from Tempe Shapes."""
 
-
+from array import array
 import gc
 from math import sqrt, log
 

--- a/examples/scatter_plot_example.py
+++ b/examples/scatter_plot_example.py
@@ -368,7 +368,7 @@ surface.text(
 async def init_display():
     from tempe_displays.st7789.pimoroni import PimoroniDisplay
 
-    display = PimoroniDisplay(size = (240, 320))
+    display = PimoroniDisplay(size=(240, 320))
     display.backlight_pin(1)
     await display.init()
     return display

--- a/examples/shapes_examples.py
+++ b/examples/shapes_examples.py
@@ -5,7 +5,7 @@
 """Example showing core Tempe Shapes."""
 
 import asyncio
-from array import array
+
 import framebuf
 import random
 import math
@@ -36,8 +36,8 @@ random.seed(0)
 
 surface = Surface()
 
-# a buffer one quarter the size of the screen
-working_buffer = array("H", bytearray(2 * 320 * 61))
+# a buffer one half the size of the screen
+working_buffer = bytearray(2 * 320 * 121)
 
 # fill the background with white pixels
 background = Rectangles([(0, 0, 320, 240)], [0xFFFF])
@@ -328,7 +328,7 @@ async def init_display():
 
     display = PimoroniDisplay(size = (240, 320))
     display.backlight_pin(1)
-    await display.init(270)
+    await display.init()
     return display
 
 

--- a/examples/shapes_examples.py
+++ b/examples/shapes_examples.py
@@ -326,7 +326,7 @@ surface.add_shape("DRAWING", ellipses_outlines)
 async def init_display():
     from tempe_displays.st7789.pimoroni import PimoroniDisplay
 
-    display = PimoroniDisplay(size = (240, 320))
+    display = PimoroniDisplay(size=(240, 320))
     display.backlight_pin(1)
     await display.init()
     return display

--- a/examples/shapes_examples.py
+++ b/examples/shapes_examples.py
@@ -5,7 +5,7 @@
 """Example showing core Tempe Shapes."""
 
 import asyncio
-
+from array import array
 import framebuf
 import random
 import math

--- a/examples/temperature_screen.py
+++ b/examples/temperature_screen.py
@@ -7,7 +7,7 @@
 Note: this is currently not working as it uses earlier version of code.
 """
 
-from array import array
+
 import asyncio
 import gc
 from machine import SPI, Pin, ADC, RTC
@@ -35,7 +35,7 @@ w = 320
 h = 240
 
 gc.collect()
-DRAWING_BUFFER = array("H", bytearray(2 * w * 31))
+DRAWING_BUFFER = bytearray(2 * w * 31)
 
 
 async def init_display():

--- a/examples/update_example.py
+++ b/examples/update_example.py
@@ -5,7 +5,6 @@
 """Example showing asyncio updating of a surface."""
 
 import asyncio
-
 from machine import ADC, RTC
 
 from tempe import colors

--- a/examples/update_example.py
+++ b/examples/update_example.py
@@ -13,8 +13,7 @@ from tempe.surface import Surface
 
 
 # a buffer one half the size of the screen
-WORKING_BUFFER = bytearray(2*240*161)
-
+WORKING_BUFFER = bytearray(2 * 240 * 161)
 
 
 async def init_surface(surface):
@@ -46,7 +45,7 @@ async def init_surface(surface):
 async def init_display():
     from tempe_displays.st7789.pimoroni import PimoroniDisplay
 
-    display = PimoroniDisplay(size = (240, 320))
+    display = PimoroniDisplay(size=(240, 320))
     display.backlight_pin(1)
     await display.init(270)
     return display
@@ -75,6 +74,7 @@ async def update_temperature(adc, text_field):
 
 async def refresh_display(surface, display, working_buffer):
     import time
+
     while True:
         await surface.refresh_needed.wait()
         start = time.ticks_us()

--- a/examples/update_example.py
+++ b/examples/update_example.py
@@ -5,7 +5,7 @@
 """Example showing asyncio updating of a surface."""
 
 import asyncio
-from array import array
+
 from machine import ADC, RTC
 
 from tempe import colors
@@ -14,7 +14,7 @@ from tempe.surface import Surface
 
 
 # a buffer one half the size of the screen
-WORKING_BUFFER = array('H', range(240*161))
+WORKING_BUFFER = bytearray(2*240*161)
 
 
 

--- a/src/tempe/display.py
+++ b/src/tempe/display.py
@@ -13,29 +13,30 @@ class Display:
 class FileDisplay(Display):
     """Display that renders raw RGB565 data to a file."""
 
-    def __init__(self, name, size=(320, 240)):
+    def __init__(self, name, size=(320, 240), pixel_size=2):
         self.name = name
         self.size = size
+        self.pixel_size = pixel_size
         self._io = None
 
     def clear(self):
         self._io.seek(0)
-        row = b"\x00\x00" * (self.size[0])
+        row = b"\x00" * (self.pixel_size * self.size[0])
         for i in range(self.size[1]):
             self._io.write(row)
 
     def blit(self, buffer, x, y, w, h):
         cols, rows = self.size
-        print(x, w, cols, y, h, rows)
         if x + w > cols or y + h > rows:
             raise ValueError("Buffer too large")
         if self._io is None:
             raise RuntimeError("File is not open")
 
         # write out a row at a time
+        ps = self.pixel_size
         for i in range(h):
-            self._io.seek(2 * (cols * (y + i) + x))
-            self._io.write(memoryview(buffer)[w * i : w * (i + 1)])
+            self._io.seek(ps * (cols * (y + i) + x))
+            self._io.write(memoryview(buffer)[ps * w * i : ps * w * (i + 1)])
 
     def __enter__(self):
         if self._io is None:

--- a/src/tempe/font.py
+++ b/src/tempe/font.py
@@ -4,7 +4,7 @@
 
 """Font ABCs and support for bitmapped fonts."""
 
-from array import array
+
 import framebuf
 
 

--- a/src/tempe/raster.py
+++ b/src/tempe/raster.py
@@ -8,17 +8,19 @@ import framebuf
 class Raster:
     """A rectangular buffer that can be drawn on by a surface."""
 
-    def __init__(self, buf, x, y, w, h, stride=None, offset=0):
+    def __init__(self, buf, x, y, w, h, stride=None, offset=0, format=framebuf.RGB565):
         stride = stride if stride is not None else w
         self.buf = buf
         self.x = x
         self.y = y
         self.w = w
         self.h = h
+        self.pixel_size = 2
         self.offset = offset
         self.stride = stride
+        self.format = format
         self.fbuf = framebuf.FrameBuffer(
-            memoryview(buf)[offset:], w, h, framebuf.RGB565, stride
+            memoryview(buf)[self.pixel_size * offset:], w, h, self.format, stride
         )
 
     @classmethod
@@ -34,4 +36,4 @@ class Raster:
         if w1 <= 0 or h1 <= 0:
             return None
         offset = self.offset + self.stride * (y1 - self.y) + (x1 - self.x)
-        return Raster(self.buf, x1, y1, w1, h1, self.stride, offset)
+        return Raster(self.buf, x1, y1, w1, h1, self.stride, offset, self.format)

--- a/src/tempe/raster.py
+++ b/src/tempe/raster.py
@@ -20,7 +20,7 @@ class Raster:
         self.stride = stride
         self.format = format
         self.fbuf = framebuf.FrameBuffer(
-            memoryview(buf)[self.pixel_size * offset:], w, h, self.format, stride
+            memoryview(buf)[self.pixel_size * offset :], w, h, self.format, stride
         )
 
     @classmethod

--- a/src/tempe/surface.py
+++ b/src/tempe/surface.py
@@ -23,6 +23,8 @@ class Surface:
         self.layers = {layer: [] for layer in LAYERS}
         self._damage = []
         self.refresh_needed = asyncio.Event()
+        self.format = framebuf.RGB565
+        self.pixel_size = 2
 
     def draw(self, raster):
         """Draw into a raster."""
@@ -41,7 +43,7 @@ class Surface:
         for rect in self._damage:
             x, y, w, h = rect
             # handle buffer too small
-            buffer_rows = (len(working_buffer) // w) - 1
+            buffer_rows = (len(working_buffer) // (w * self.pixel_size) ) - 1
             for start_row in range(0, h, buffer_rows):
                 raster_rows = min(buffer_rows, h - start_row)
                 raster = Raster(working_buffer, x, y + start_row, w, raster_rows)

--- a/src/tempe/surface.py
+++ b/src/tempe/surface.py
@@ -43,7 +43,7 @@ class Surface:
         for rect in self._damage:
             x, y, w, h = rect
             # handle buffer too small
-            buffer_rows = (len(working_buffer) // (w * self.pixel_size) ) - 1
+            buffer_rows = (len(working_buffer) // (w * self.pixel_size)) - 1
             for start_row in range(0, h, buffer_rows):
                 raster_rows = min(buffer_rows, h - start_row)
                 raster = Raster(working_buffer, x, y + start_row, w, raster_rows)

--- a/src/tempe_displays/st7789/base.py
+++ b/src/tempe_displays/st7789/base.py
@@ -361,7 +361,7 @@ class ST7789:
         self.window(x, y, w, h)
         if stride is None:
             # fast path for contiguous memory
-            self.write_to_memory(buf[:2 * w * h])
+            self.write_to_memory(buf[: 2 * w * h])
         else:
             buf = memoryview(buf)
             self.window(x, y, w, h)
@@ -371,5 +371,5 @@ class ST7789:
                 (
                     buf[offset : offset + 2 * w]
                     for offset in range(0, 2 * stride * h, 2 * stride)
-                )
+                ),
             )

--- a/src/tempe_displays/st7789/base.py
+++ b/src/tempe_displays/st7789/base.py
@@ -361,7 +361,7 @@ class ST7789:
         self.window(x, y, w, h)
         if stride is None:
             # fast path for contiguous memory
-            self.write_to_memory(buf[:w * h])
+            self.write_to_memory(buf[:2 * w * h])
         else:
             buf = memoryview(buf)
             self.window(x, y, w, h)
@@ -369,7 +369,7 @@ class ST7789:
             self.send_iterator(
                 1,
                 (
-                    buf[offset : offset + w]
-                    for offset in range(0, stride * h, stride)
+                    buf[offset : offset + 2 * w]
+                    for offset in range(0, 2 * stride * h, 2 * stride)
                 )
             )

--- a/src/tempe_displays/st7789/pimoroni.py
+++ b/src/tempe_displays/st7789/pimoroni.py
@@ -116,7 +116,7 @@ class PimoroniDisplay(ST7789_SPI):
         await self.normal_on()
 
         if rotation == 90:
-            self.memory_data_access_control(MADCTL_MH | MADCTL_MX| MADCTL_MY)
+            self.memory_data_access_control(MADCTL_MH | MADCTL_MX | MADCTL_MY)
             if self.centered:
                 self.x_offset = (240 - self.size[0]) // 2 + (240 - self.size[0]) % 2
                 self.y_offset = (320 - self.size[1]) // 2 + (320 - self.size[0]) % 2

--- a/src/tempe_displays/st7789/spi.py
+++ b/src/tempe_displays/st7789/spi.py
@@ -41,4 +41,3 @@ class ST7789_SPI(ST7789):
             if buf:
                 write(buf)
         self.cs_pin(1)
-

--- a/tests/tempe/test_examples.py
+++ b/tests/tempe/test_examples.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-import array
 import gc
 import unittest
 
 from tempe.display import FileDisplay
 
-working_buffer = array.array("H", bytearray(320 * 61 * 2))
+working_buffer = bytearray(320 * 61 * 2)
 
 
 class TestExamples(unittest.TestCase):


### PR DESCRIPTION
This now just uses plain bytearrays throughout, which can be allocated extremely efficiently and without the penalty of memory copies.

Fixes #36