### PR TITLE
Improved handling of reset in ST7789 display

### DIFF
--- a/src/tempe_displays/st7789/base.py
+++ b/src/tempe_displays/st7789/base.py
@@ -104,6 +104,8 @@ class ST7789:
 
     def __init__(self, size, reset_pin=None):
         self.size = size
+        if isinstance(reset_pin, int):
+            reset_pin = Pin(reset_pin, Pin.OUT)
         self.reset_pin = reset_pin
         self.x_offset = 0
         self.y_offset = 0


### PR DESCRIPTION
If the reset pin is passed as an int, convert to machine.Pin.

Fixes #55.